### PR TITLE
chore: add security scanning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,7 +192,7 @@ jobs:
           retention-days: 7
 
 
-codeql:
+  codeql:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We actually can't enable this until the repo's public :disappointed: 