### PR TITLE
fix: remount ro filesystems to id-shift

### DIFF
--- a/cli/docker.go
+++ b/cli/docker.go
@@ -487,7 +487,7 @@ func runDockerCVM(ctx context.Context, log slog.Logger, client dockerutil.Docker
 		// the inner container.
 		if m.ReadOnly {
 			mounter := xunix.Mounter(ctx)
-			err = mounter.Mount(m.Source, m.Source, "", []string{"remount, rw"})
+			err := mounter.Mount("", m.Source, "", []string{"remount,rw"})
 			if err != nil {
 				return xerrors.Errorf("remount: %w", err)
 			}

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -95,7 +95,7 @@ func TestDocker(t *testing.T) {
 
 		binds = append(binds,
 			bindMount(homeDir, "/home/coder", false),
-			bindMount(secretDir, "/var/secrets", false),
+			bindMount(secretDir, "/var/secrets", true),
 		)
 
 		var (


### PR DESCRIPTION
Binds that are mounted read-only must be remounted rw in the outer container so that we can id shift them appropriately.

fixes #12 