### PR TITLE
chore: run build job on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,7 +166,6 @@ jobs:
 
   build:
     runs-on: ubuntu-20.04
-    if: github.ref != 'refs/heads/main'
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3


### PR DESCRIPTION
- This lets Trivy run against the main branch.