### PR TITLE
fix(envbox): work with cgroupv2

### DIFF
--- a/cli/clitest/fs.go
+++ b/cli/clitest/fs.go
@@ -16,9 +16,9 @@ func FakeSysboxManagerReady(t *testing.T, fs afero.Fs) {
 }
 
 func FakeCPUGroups(t *testing.T, fs afero.Fs, quota, period string) {
-	err := afero.WriteFile(fs, xunix.CPUPeriodPath, []byte(period), 0o600)
+	err := afero.WriteFile(fs, xunix.CPUPeriodPathCGroupV1, []byte(period), 0o600)
 	require.NoError(t, err)
 
-	err = afero.WriteFile(fs, xunix.CPUQuotaPath, []byte(quota), 0o600)
+	err = afero.WriteFile(fs, xunix.CPUQuotaPathCGroupV1, []byte(quota), 0o600)
 	require.NoError(t, err)
 }

--- a/cli/docker.go
+++ b/cli/docker.go
@@ -630,9 +630,9 @@ func runDockerCVM(ctx context.Context, log slog.Logger, client dockerutil.Docker
 		return xerrors.Errorf("make bootstrap dir: %w", err)
 	}
 
-	cpuQuota, err := xunix.ReadCPUQuota(ctx)
+	cpuQuota, err := xunix.ReadCPUQuota(ctx, blog)
 	if err != nil {
-		return xerrors.Errorf("read CPU quota: %w", err)
+		blog.Errorf("Unable to read CPU quota: %w", err)
 	}
 
 	log.Debug(ctx, "setting CPU quota",
@@ -644,7 +644,8 @@ func runDockerCVM(ctx context.Context, log slog.Logger, client dockerutil.Docker
 	// so that processes inside the container know what they're working with.
 	err = dockerutil.SetContainerCPUQuota(ctx, containerID, cpuQuota.Quota, cpuQuota.Period)
 	if err != nil {
-		return xerrors.Errorf("set inner container CPU quota: %w", err)
+		blog.Errorf("Unable to set quota for inner container: %w", err)
+		blog.Errorf("This is not a fatal error, but it may cause CGroup-aware applications to misbehave.")
 	}
 
 	blog.Info("Envbox startup complete!")

--- a/dockerutil/container_test.go
+++ b/dockerutil/container_test.go
@@ -1,0 +1,82 @@
+package dockerutil_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/envbox/dockerutil"
+	"github.com/coder/envbox/xunix"
+	"github.com/coder/envbox/xunix/xunixfake"
+)
+
+func TestSetContainerQuota(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		Name        string
+		Quota       xunix.CPUQuota
+		ContainerID string
+		ExpectedFS  map[string]string
+		Error       string
+	}{
+		{
+			Name: "CGroupV1",
+			Quota: xunix.CPUQuota{
+				Quota:  150000,
+				Period: 100000,
+				CGroup: xunix.CGroupV1,
+			},
+			ContainerID: "dummy",
+			ExpectedFS: map[string]string{
+				"/sys/fs/cgroup/cpu,cpuacct/docker/dummy/syscont-cgroup-root/cpu.cfs_quota_us":  "150000",
+				"/sys/fs/cgroup/cpu,cpuacct/docker/dummy/syscont-cgroup-root/cpu.cfs_period_us": "100000",
+			},
+		},
+		{
+			Name: "CGroupV2",
+			Quota: xunix.CPUQuota{
+				Quota:  150000,
+				Period: 100000,
+				CGroup: xunix.CGroupV2,
+			},
+			ContainerID: "dummy",
+			ExpectedFS: map[string]string{
+				"/sys/fs/cgroup/docker/dummy/init.scope/cpu.max": "150000 100000",
+			},
+		},
+		{
+			Name: "CGroupV2Max",
+			Quota: xunix.CPUQuota{
+				Quota:  -1,
+				Period: 100000,
+				CGroup: xunix.CGroupV2,
+			},
+			ContainerID: "dummy",
+			ExpectedFS: map[string]string{
+				"/sys/fs/cgroup/docker/dummy/init.scope/cpu.max": "max 100000",
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			tmpfs := &xunixfake.MemFS{MemMapFs: &afero.MemMapFs{}}
+			ctx := xunix.WithFS(context.Background(), tmpfs)
+			err := dockerutil.SetContainerQuota(ctx, tc.ContainerID, tc.Quota)
+			if tc.Error == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.Error)
+			}
+			for path, content := range tc.ExpectedFS {
+				actualContent, err := afero.ReadFile(tmpfs, path)
+				require.NoError(t, err)
+				require.Equal(t, content, string(bytes.TrimSpace(actualContent)))
+			}
+		})
+	}
+}

--- a/xunix/sys.go
+++ b/xunix/sys.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/afero"
 	"golang.org/x/xerrors"
 
-	"github.com/coder/envbox/buildlog"
+	"cdr.dev/slog"
 )
 
 type CPUQuota struct {
@@ -46,14 +46,13 @@ const (
 // Relevant paths for cgroupv1:
 // - /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us
 // - /sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us
-func ReadCPUQuota(ctx context.Context, blog buildlog.Logger) (CPUQuota, error) {
+func ReadCPUQuota(ctx context.Context, log slog.Logger) (CPUQuota, error) {
 	quota, err := readCPUQuotaCGroupV2(ctx)
 	if err == nil {
 		return quota, nil
 	}
 
-	blog.Infof("Unable to read cgroupv2 quota, error: %s", err.Error())
-	blog.Info("Falling back to cgroupv1.")
+	log.Info(ctx, "Unable to read cgroupv2 quota, falling back to cgroupv1", slog.Error(err))
 	return readCPUQuotaCGroupV1(ctx)
 }
 

--- a/xunix/sys.go
+++ b/xunix/sys.go
@@ -3,7 +3,9 @@ package xunix
 import (
 	"bytes"
 	"context"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/afero"
 	"golang.org/x/xerrors"
@@ -12,14 +14,71 @@ import (
 type CPUQuota struct {
 	Quota  int
 	Period int
+	CGroup CGroup
 }
 
 const (
-	CPUPeriodPath = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us"
-	CPUQuotaPath  = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us"
+	CPUPeriodPathCGroupV1 = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us"
+	CPUQuotaPathCGroupV1  = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us"
+	CPUMaxPathCGroupV2    = "/sys/fs/cgroup/"
+)
+
+type CGroup string
+
+const (
+	CGroupV1 CGroup = "cgroupv1"
+	CGroupV2 CGroup = "cgroupv2"
 )
 
 func ReadCPUQuota(ctx context.Context) (CPUQuota, error) {
+	// Try first to read the cgroupv2 version.
+	if quota, err := readCPUQuotaCGroupV2(ctx); err == nil {
+		// TODO: log this somewhere
+		return quota, nil
+	}
+
+	// Fall back to cgroupv1
+	return readCPUQuotaCGroupV1(ctx)
+}
+
+func readCPUQuotaCGroupV2(ctx context.Context) (CPUQuota, error) {
+	fs := GetFS(ctx)
+	self, err := ReadCGroupSelf(ctx, "") // TODO: should we just go from the first line?
+	if err != nil {
+		return CPUQuota{}, xerrors.Errorf("")
+	}
+
+	maxStr, err := afero.ReadFile(fs, filepath.Join("/sys/fs/cgroup/", self, "cpu.max"))
+	if err != nil {
+		return CPUQuota{}, xerrors.Errorf("read cpu.max outside container: %w", err)
+	}
+
+	list := strings.Split(string(maxStr), " ")
+	if len(list) != 2 {
+		return CPUQuota{}, xerrors.Errorf("expected cpu.max to have exactly two entries, got: %s", string(maxStr))
+	}
+
+	var quota int
+	var period int
+
+	if list[0] == "max" {
+		quota = -1
+	} else {
+		quota, err = strconv.Atoi(list[0])
+		if err != nil {
+			return CPUQuota{}, xerrors.Errorf("quota %s not an int: %w", list[0], err)
+		}
+	}
+
+	period, err = strconv.Atoi(list[1])
+	if err != nil {
+		return CPUQuota{}, xerrors.Errorf("period %s not an int: %w", list[1], err)
+	}
+
+	return CPUQuota{Quota: quota, Period: period, CGroup: CGroupV2}, nil
+}
+
+func readCPUQuotaCGroupV1(ctx context.Context) (CPUQuota, error) {
 	fs := GetFS(ctx)
 	periodStr, err := afero.ReadFile(fs, "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us")
 	if err != nil {
@@ -45,4 +104,38 @@ func ReadCPUQuota(ctx context.Context) (CPUQuota, error) {
 		Quota:  quota,
 		Period: period,
 	}, nil
+}
+
+// readCGroup reads the lines of /proc/self/cgroup where the third field
+// (separated by `:`) of the line starts with prefix.
+// If prefix is empty, we just check the first line.
+// pid is a string so you can use `self` to look at your own cgroup.
+func ReadCGroupSelf(ctx context.Context, prefix string) (string, error) {
+	fs := GetFS(ctx)
+	raw, err := afero.ReadFile(fs, "/proc/self/cgroup")
+	if err != nil {
+		return "", xerrors.Errorf("read /proc/self/cgroup: %w", err)
+	}
+
+	lines := bytes.Split(raw, []byte("\n"))
+	if len(lines) == 0 {
+		return "", xerrors.Errorf("unexpected content of /proc/self/cgroup: %s", string(raw))
+	}
+
+	// Loop through all the lines
+	for _, line := range lines {
+		fields := bytes.Split(line, []byte(":"))
+		if len(fields) != 3 {
+			return "", xerrors.Errorf("expected 3 fields in last line of /proc/self/cgroup: %s", string(raw))
+		}
+
+		// An empty prefix will always match.
+		if !bytes.HasPrefix(fields[2], []byte(prefix)) {
+			continue
+		}
+
+		return string(fields[2]), nil
+	}
+
+	return "", xerrors.Errorf("no cgroup found with prefix %s", prefix)
 }

--- a/xunix/sys_test.go
+++ b/xunix/sys_test.go
@@ -2,12 +2,12 @@ package xunix_test
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
+	"github.com/coder/envbox/buildlog"
 	"github.com/coder/envbox/xunix"
 	"github.com/coder/envbox/xunix/xunixfake"
 )
@@ -15,31 +15,71 @@ import (
 func TestReadCPUQuota(t *testing.T) {
 	t.Parallel()
 
-	t.Run("OK", func(t *testing.T) {
-		t.Parallel()
-
-		var (
-			fs  = &xunixfake.MemFS{MemMapFs: &afero.MemMapFs{}}
-			ctx = xunix.WithFS(context.Background(), fs)
-		)
-
-		const (
-			period     = 1234
-			quota      = 5678
-			periodPath = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us"
-			quotaPath  = "/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us"
-		)
-
-		err := afero.WriteFile(fs, periodPath, []byte(strconv.Itoa(period)), 0o644)
-		require.NoError(t, err)
-
-		err = afero.WriteFile(fs, quotaPath, []byte(strconv.Itoa(quota)), 0o644)
-		require.NoError(t, err)
-
-		cpuQuota, err := xunix.ReadCPUQuota(ctx)
-		require.NoError(t, err)
-
-		require.Equal(t, period, cpuQuota.Period)
-		require.Equal(t, quota, cpuQuota.Quota)
-	})
+	for _, tc := range []struct {
+		Name     string
+		Subpath  string
+		FS       map[string]string
+		Expected xunix.CPUQuota
+		Error    string
+	}{
+		{
+			Name:    "CGroupV1",
+			Subpath: "docker/dummy",
+			FS: map[string]string{
+				xunix.CPUQuotaPathCGroupV1:  "150000",
+				xunix.CPUPeriodPathCGroupV1: "100000",
+			},
+			Expected: xunix.CPUQuota{Quota: 150000, Period: 100000, CGroup: xunix.CGroupV1},
+		},
+		{
+			Name:    "CGroupV1_Invalid",
+			Subpath: "docker/dummy",
+			FS: map[string]string{
+				xunix.CPUQuotaPathCGroupV1:  "100000",
+				xunix.CPUPeriodPathCGroupV1: "invalid",
+			},
+			Error: `period invalid not an int`,
+		},
+		{
+			Name:    "CGroupV2",
+			Subpath: "docker/dummy",
+			FS: map[string]string{
+				"/proc/self/cgroup":                             "0::/kubepods/pod/container",
+				"/sys/fs/cgroup/kubepods/pod/container/cpu.max": "150000 100000",
+			},
+			Expected: xunix.CPUQuota{Quota: 150000, Period: 100000, CGroup: xunix.CGroupV2},
+		},
+		{
+			Name:    "CGroupV2_Max",
+			Subpath: "docker/dummy",
+			FS: map[string]string{
+				"/proc/self/cgroup":                             "0::/kubepods/pod/container",
+				"/sys/fs/cgroup/kubepods/pod/container/cpu.max": "max 100000",
+			},
+			Expected: xunix.CPUQuota{Quota: -1, Period: 100000, CGroup: xunix.CGroupV2},
+		},
+		{
+			Name:  "Empty",
+			FS:    map[string]string{},
+			Error: "file does not exist",
+		},
+	} {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			tmpfs := &xunixfake.MemFS{MemMapFs: &afero.MemMapFs{}}
+			ctx := xunix.WithFS(context.Background(), tmpfs)
+			for path, content := range tc.FS {
+				require.NoError(t, afero.WriteFile(tmpfs, path, []byte(content), 0o644))
+			}
+			actual, err := xunix.ReadCPUQuota(ctx, &buildlog.NopLogger{})
+			if tc.Error == "" {
+				require.NoError(t, err)
+				require.Equal(t, tc.Expected, actual)
+			} else {
+				require.ErrorContains(t, err, tc.Error)
+				require.Zero(t, actual)
+			}
+		})
+	}
 }

--- a/xunix/sys_test.go
+++ b/xunix/sys_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
-	"github.com/coder/envbox/buildlog"
+	"cdr.dev/slog/sloggers/slogtest"
+
 	"github.com/coder/envbox/xunix"
 	"github.com/coder/envbox/xunix/xunixfake"
 )
@@ -67,12 +68,13 @@ func TestReadCPUQuota(t *testing.T) {
 		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
+			log := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true})
 			tmpfs := &xunixfake.MemFS{MemMapFs: &afero.MemMapFs{}}
 			ctx := xunix.WithFS(context.Background(), tmpfs)
 			for path, content := range tc.FS {
 				require.NoError(t, afero.WriteFile(tmpfs, path, []byte(content), 0o644))
 			}
-			actual, err := xunix.ReadCPUQuota(ctx, &buildlog.NopLogger{})
+			actual, err := xunix.ReadCPUQuota(ctx, log)
 			if tc.Error == "" {
 				require.NoError(t, err)
 				require.Equal(t, tc.Expected, actual)

--- a/xunix/sys_test.go
+++ b/xunix/sys_test.go
@@ -26,8 +26,8 @@ func TestReadCPUQuota(t *testing.T) {
 			Name:    "CGroupV1",
 			Subpath: "docker/dummy",
 			FS: map[string]string{
-				xunix.CPUQuotaPathCGroupV1:  "150000",
-				xunix.CPUPeriodPathCGroupV1: "100000",
+				xunix.CPUQuotaPathCGroupV1:  "150000\n",
+				xunix.CPUPeriodPathCGroupV1: "100000\n",
 			},
 			Expected: xunix.CPUQuota{Quota: 150000, Period: 100000, CGroup: xunix.CGroupV1},
 		},
@@ -35,8 +35,8 @@ func TestReadCPUQuota(t *testing.T) {
 			Name:    "CGroupV1_Invalid",
 			Subpath: "docker/dummy",
 			FS: map[string]string{
-				xunix.CPUQuotaPathCGroupV1:  "100000",
-				xunix.CPUPeriodPathCGroupV1: "invalid",
+				xunix.CPUQuotaPathCGroupV1:  "100000\n",
+				xunix.CPUPeriodPathCGroupV1: "invalid\n",
 			},
 			Error: `period invalid not an int`,
 		},
@@ -44,8 +44,8 @@ func TestReadCPUQuota(t *testing.T) {
 			Name:    "CGroupV2",
 			Subpath: "docker/dummy",
 			FS: map[string]string{
-				"/proc/self/cgroup":                             "0::/kubepods/pod/container",
-				"/sys/fs/cgroup/kubepods/pod/container/cpu.max": "150000 100000",
+				"/proc/self/cgroup":                             "0::/kubepods/pod/container\n",
+				"/sys/fs/cgroup/kubepods/pod/container/cpu.max": "150000 100000\n",
 			},
 			Expected: xunix.CPUQuota{Quota: 150000, Period: 100000, CGroup: xunix.CGroupV2},
 		},
@@ -53,8 +53,8 @@ func TestReadCPUQuota(t *testing.T) {
 			Name:    "CGroupV2_Max",
 			Subpath: "docker/dummy",
 			FS: map[string]string{
-				"/proc/self/cgroup":                             "0::/kubepods/pod/container",
-				"/sys/fs/cgroup/kubepods/pod/container/cpu.max": "max 100000",
+				"/proc/self/cgroup":                             "0::/kubepods/pod/container\n",
+				"/sys/fs/cgroup/kubepods/pod/container/cpu.max": "max 100000\n",
 			},
 			Expected: xunix.CPUQuota{Quota: -1, Period: 100000, CGroup: xunix.CGroupV2},
 		},


### PR DESCRIPTION
Fixes https://github.com/coder/envbox/issues/28

- No longer fails when trying to copy outer container quota to inner container.
  Warns in buildlog instead.
- Adds logic to determine current cgroup from /proc/self/cgroup
- Adds logic to read cpu.max from /sys/fs/cgroup/<self>/cpu.max
- Adds logic to write cpu.max to /sys/fs/cgroup/docker/<containerid>/init.scope/cpu.max
- Adds more unit tests around all of the above for both cgroupv1 and cgroupv2

Tested on:
- Rocky 9.1, kernel 5.14.0-162.23.1.el9_1.x86_64
- k3s v1.26.4
- Coder v0.23.2

Tested with both `systemd.unified_cgroup_hierarchy=1` and `systemd.unified_cgroup_hierarchy=0`.

You can test yourself with the envbox image `gcr.io/coder-dev-1/coder-cian/envboxv2:pr34`


![Screenshot 2023-05-10 at 12 09 16](https://github.com/coder/envbox/assets/4949514/72448fbf-d00c-454e-bea1-4e50a828d509)

![Screenshot 2023-05-10 at 12 06 58](https://github.com/coder/envbox/assets/4949514/97b0d626-0100-4a2c-a9ac-b536b14c1bcf)

