### PR TITLE
chore: set CGO_ENABLED=0 to remove dependency on glibc versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 	rm -rf build
 
 build/envbox: $(GO_FILES)
-	go build -o build/envbox ./cmd/envbox
+	CGO_ENABLED=0 go build -o build/envbox ./cmd/envbox
 
 .PHONY: build/image/envbox
 build/image/envbox: build/image/envbox/.ctx


### PR DESCRIPTION
After building envbox on a system with glibc 2.35, it refused to run on a system with glibc 2.34. Setting `CGO_ENABLED=0` in the Makefile appears to resolve this.