### PR TITLE
fix(dockerutil): use base64url for auth config encoding

### DIFF
--- a/cli/docker_test.go
+++ b/cli/docker_test.go
@@ -389,7 +389,7 @@ func TestDocker(t *testing.T) {
 		)
 
 		raw := []byte(`{"username":"_json_key","password":"{\"type\": \"service_account\", \"project_id\": \"some-test\", \"private_key_id\": \"blahblah\", \"private_key\": \"-----BEGIN PRIVATE KEY-----mykey-----END PRIVATE KEY-----\", \"client_email\": \"test@test.iam.gserviceaccount.com\", \"client_id\": \"123\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"https://oauth2.googleapis.com/token\", \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\", \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/test.iam.gserviceaccount.com\" }","auth":"X2pzb25fa2V5OnsKCgkidHlwZSI6ICJzZXJ2aWNlX2FjY291bnQiLAoJInByb2plY3RfaWQiOiAic29tZS10ZXN0IiwKCSJwcml2YXRlX2tleV9pZCI6ICJibGFoYmxhaCIsCgkicHJpdmF0ZV9rZXkiOiAiLS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCm15a2V5LS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQoiLAoJImNsaWVudF9lbWFpbCI6ICJ0ZXN0QHRlc3QuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLAoJImNsaWVudF9pZCI6ICIxMjMiLAoJImF1dGhfdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi9hdXRoIiwKCSJ0b2tlbl91cmkiOiAiaHR0cHM6Ly9vYXV0aDIuZ29vZ2xlYXBpcy5jb20vdG9rZW4iLAoJImF1dGhfcHJvdmlkZXJfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3d3dy5nb29nbGVhcGlzLmNvbS9vYXV0aDIvdjEvY2VydHMiLAoJImNsaWVudF94NTA5X2NlcnRfdXJsIjogImh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL3JvYm90L3YxL21ldGFkYXRhL3g1MDkvdGVzdC5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIKfQo=","email":"test@test.iam.gserviceaccount.com"}`)
-		authB64 := base64.StdEncoding.EncodeToString(raw)
+		authB64 := base64.URLEncoding.EncodeToString(raw)
 
 		client := clitest.DockerClient(t, ctx)
 		client.ImagePullFn = func(_ context.Context, ref string, options dockertypes.ImagePullOptions) (io.ReadCloser, error) {

--- a/dockerutil/client.go
+++ b/dockerutil/client.go
@@ -42,7 +42,7 @@ func (a AuthConfig) Base64() (string, error) {
 	if err != nil {
 		return "", xerrors.Errorf("json marshal: %w", err)
 	}
-	return base64.StdEncoding.EncodeToString(authStr), nil
+	return base64.URLEncoding.EncodeToString(authStr), nil
 }
 
 func ParseAuthConfig(raw string) (AuthConfig, error) {


### PR DESCRIPTION
Needs to be base64url according to the [Docker docs](https://docs.docker.com/engine/api/v1.42/#section/Authentication)

Tested with CODER_INNER_IMAGE set to image hosted in a registry behind basic auth that has some funky characters in the password like `~` and `.`.


Before: envbox (ghcr.io/coder/envbox:5ef860c) image pull fails with following error: 
  ```
{"ts":"2023-07-06T16:53:24.81088446Z","level":"DEBUG","msg":"child log","caller":"/home/runner/work/envbox/envbox/background/process.go:248","func":"github.com/coder/envbox/background.scanIntoLog","logger_names":["dockerd"],"fields":{"process":"dockerd","content":"time=\"2023-07-06T16:53:24.810799902Z\" level=debug msg=\"Trying to pull registry.c3s.int.sporc.space/enterprise-base from https://registry.c3s.int.sporc.space\""}}
{"ts":"2023-07-06T16:53:24.82029139Z","level":"INFO","msg":"child log","caller":"/home/runner/work/envbox/envbox/background/process.go:248","func":"github.com/coder/envbox/background.scanIntoLog","logger_names":["dockerd"],"fields":{"process":"dockerd","content":"time=\"2023-07-06T16:53:24.820233332Z\" level=info msg=\"Attempting next endpoint for pull after error: Head \\\"https://registry.c3s.int.sporc.space/v2/enterprise-base/manifests/ubuntu\\\": no basic auth credentials\""}}
{"ts":"2023-07-06T16:53:24.822953956Z","level":"ERROR","msg":"child log","caller":"/home/runner/work/envbox/envbox/background/process.go:248","func":"github.com/coder/envbox/background.scanIntoLog","logger_names":["dockerd"],"fields":{"process":"dockerd","content":"time=\"2023-07-06T16:53:24.822915664Z\" level=error msg=\"Handler for POST /v1.42/images/create returned error: Head \\\"https://registry.c3s.int.sporc.space/v2/enterprise-base/manifests/ubuntu\\\": no basic auth credentials\""}}
{"ts":"2023-07-06T16:53:24.855096274Z","level":"DEBUG","msg":"child log","caller":"/home/runner/work/envbox/envbox/background/process.go:248","func":"github.com/coder/envbox/background.scanIntoLog","logger_names":["dockerd"],"fields":{"process":"dockerd","content":"time=\"2023-07-06T16:53:24.855032795Z\" level=debug msg=\"garbage collected\" d=6.971699ms"}}
{"output":"Failed to run envbox: pull image: pull image: pull image: Error response from daemon: Head \"https://registry.c3s.int.sporc.space/v2/enterprise-base/manifests/ubuntu\": no basic auth credentials","time":"2023-07-06T16:53:27.823162905Z","type":"error"}
{"output":"Failed to run envbox: run: pull image: pull image: pull image: Error response from daemon: Head \"https://registry.c3s.int.sporc.space/v2/enterprise-base/manifests/ubuntu\": no basic auth credentials","time":"2023-07-06T16:53:27.823225122Z","type":"error"}
{"output":"","time":"2023-07-06T16:53:27.823232586Z","type":"done"}
run: pull image: pull image: pull image: Error response from daemon: Head "https://registry.c3s.int.sporc.space/v2/enterprise-base/manifests/ubuntu": no basic auth credentials
  ```

After: envbox (gcr.io/coder-dev-1/coder-cian/envbox:pr42) successfully pulls inner image and starts workspace.
