### PR TITLE
chore: test memory limits are being set on inner container

### DIFF
--- a/cli/cliflag/cliflag.go
+++ b/cli/cliflag/cliflag.go
@@ -110,7 +110,7 @@ func IntVarP(flagset *pflag.FlagSet, ptr *int, name string, shorthand string, en
 		return
 	}
 
-	vi64, err := strconv.ParseUint(val, 10, 8)
+	vi64, err := strconv.ParseInt(val, 10, 64)
 	if err != nil {
 		flagset.IntVarP(ptr, name, shorthand, def, fmtUsage(usage, env))
 		return

--- a/cli/cliflag/cliflag.go
+++ b/cli/cliflag/cliflag.go
@@ -110,13 +110,13 @@ func IntVarP(flagset *pflag.FlagSet, ptr *int, name string, shorthand string, en
 		return
 	}
 
-	vi64, err := strconv.ParseInt(val, 10, 64)
+	vi64, err := strconv.Atoi(val)
 	if err != nil {
 		flagset.IntVarP(ptr, name, shorthand, def, fmtUsage(usage, env))
 		return
 	}
 
-	flagset.IntVarP(ptr, name, shorthand, int(vi64), fmtUsage(usage, env))
+	flagset.IntVarP(ptr, name, shorthand, vi64, fmtUsage(usage, env))
 }
 
 func Bool(flagset *pflag.FlagSet, name, shorthand, env string, def bool, usage string) {

--- a/integration/integrationtest/docker.go
+++ b/integration/integrationtest/docker.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coder/envbox/buildlog"
 	"github.com/coder/envbox/cli"
+	"github.com/coder/envbox/dockerutil"
 	"github.com/coder/retry"
 )
 
@@ -47,6 +48,7 @@ type CreateDockerCVMConfig struct {
 	Mounts          []string
 	AddFUSE         bool
 	AddTUN          bool
+	CPUs            int
 }
 
 func (c CreateDockerCVMConfig) validate(t *testing.T) {
@@ -85,6 +87,8 @@ func RunEnvbox(t *testing.T, pool *dockertest.Pool, conf *CreateDockerCVMConfig)
 	}, func(host *docker.HostConfig) {
 		host.Binds = conf.Binds
 		host.Privileged = true
+		host.CPUPeriod = int64(dockerutil.DefaultCPUPeriod)
+		host.CPUQuota = int64(conf.CPUs) * int64(dockerutil.DefaultCPUPeriod)
 	})
 	require.NoError(t, err)
 	// t.Cleanup(func() { _ = pool.Purge(resource) })


### PR DESCRIPTION
- Fixed an issue where large integers CLI arguments were not parsed correctly
- Added an integration test to validate CPU/memory are set correctly in
  the inner container.