### PR TITLE
chore: pin docker version to avoid incompatibilities

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       # Install Go!
       - uses: actions/setup-go@v3
         with:
-          go-version: "~1.20"
+          go-version: "1.20.5"
 
       # Check for Go linting errors!
       - name: Lint Go

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       # Install Go!
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20.5"
+          go-version: "~1.20"
 
       # Check for Go linting errors!
       - name: Lint Go
@@ -136,7 +136,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "~1.20"
+          go-version: "1.20.5"
 
       # Sadly the new "set output" syntax (of writing env vars to
       # $GITHUB_OUTPUT) does not work on both powershell and bash so we use the
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "~1.20"
+          go-version: "1.20.5"
 
       - name: Go Cache Paths
         id: go-cache-paths
@@ -254,7 +254,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "~1.20"
+          go-version: "1.20.5"
 
       - name: build image
         run: make -j build/image/envbox

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "~1.20"
+          go-version: "1.20.5"
 
       - name: Go Cache Paths
         id: go-cache-paths

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -12,6 +12,9 @@ LABEL \
 
 # Basic utilities
 ARG DEBIAN_FRONTEND=noninteractive
+# Pin docker to avoid any breaking API changes between the Go client and 
+# the server.
+ARG DOCKER_VERSION="5:24.0.3-1~ubuntu.20.04~focal"
 #   Ignore other repositories, as some require HTTPS
 RUN apt-get update --quiet --option Dir::Etc::SourceParts="" && \
     apt-get upgrade -y && \
@@ -37,8 +40,8 @@ RUN apt-get update --quiet --option Dir::Etc::SourceParts="" && \
     apt-get update --quiet && \
     apt-get install --no-install-recommends --yes --quiet \
       containerd.io \
-      docker-ce \
-      docker-ce-cli && \
+      docker-ce=$DOCKER_VERSION \
+      docker-ce-cli=$DOCKER_VERSION && \
     # Delete package cache to avoid consuming space in layer
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/dockerutil/image.go
+++ b/dockerutil/image.go
@@ -145,7 +145,7 @@ type ImageMetadata struct {
 }
 
 // GetImageMetadata returns metadata about an image such as the UID/GID of the
-// provided // username and whether it contains an /sbin/init that we should run.
+// provided username and whether it contains an /sbin/init that we should run.
 func GetImageMetadata(ctx context.Context, client DockerClient, image, username string) (ImageMetadata, error) {
 	// Creating a dummy container to inspect the filesystem.
 	created, err := client.ContainerCreate(ctx,


### PR DESCRIPTION
The problem with the integration tests was an incompatibility between Docker and Go `1.20.6` so this also pins Go to `1.20.5` (temporarily).