### PR TITLE
ci: fetch tags in order to get version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,6 +251,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
+        with:
+          # Needed to get older tags
+          fetch-depth: 0
 
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
https://github.com/coder/envbox/actions/runs/9764876997/job/26954239536#step:6:8

alternatively, we just tag with the git SHA and don't include the latest tag