### PR TITLE
feat: add support for copying certs to dockerd's registry directory

### DIFF
--- a/cli/clitest/cli.go
+++ b/cli/clitest/cli.go
@@ -49,7 +49,7 @@ func New(t *testing.T, cmd string, args ...string) (context.Context, *cobra.Comm
 
 	var (
 		execer = NewFakeExecer()
-		fs     = NewMemFS()
+		fs     = xunixfake.NewMemFS()
 		mnt    = &mount.FakeMounter{}
 		client = NewFakeDockerClient()
 		iface  = GetNetLink(t)

--- a/cli/clitest/fake.go
+++ b/cli/clitest/fake.go
@@ -8,20 +8,12 @@ import (
 	"strings"
 
 	dockertypes "github.com/docker/docker/api/types"
-	"github.com/spf13/afero"
 	testingexec "k8s.io/utils/exec/testing"
 
 	"github.com/coder/envbox/dockerutil"
 	"github.com/coder/envbox/dockerutil/dockerfake"
 	"github.com/coder/envbox/xunix/xunixfake"
 )
-
-func NewMemFS() *xunixfake.MemFS {
-	return &xunixfake.MemFS{
-		MemMapFs: &afero.MemMapFs{},
-		Owner:    map[string]xunixfake.FileOwner{},
-	}
-}
 
 func NewFakeExecer() *xunixfake.FakeExec {
 	return &xunixfake.FakeExec{

--- a/dockerutil/registry.go
+++ b/dockerutil/registry.go
@@ -1,0 +1,92 @@
+package dockerutil
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/afero"
+	"golang.org/x/xerrors"
+
+	"github.com/coder/envbox/xunix"
+)
+
+// WriteCertsForRegistry writes the certificates found in the provided directory
+// to the correct subdirectory that the Docker daemon uses when pulling images
+// from the specified private registry.
+func WriteCertsForRegistry(ctx context.Context, registryName, certsDir string) error {
+	fs := xunix.GetFS(ctx)
+
+	// Docker certs directory.
+	registryCertsDir := filepath.Join("/etc/docker/certs.d", registryName)
+
+	// If the directory already exists it means someone
+	// has either wrapped the image or has mounted in certs
+	// manually. We should assume the user knows what they're
+	// doing and avoid mucking with their solution.
+	if _, err := fs.Stat(registryCertsDir); err == nil {
+		return nil
+	}
+
+	// Ensure the registry certs directory exists.
+	err := fs.MkdirAll(registryCertsDir, 0755)
+	if err != nil {
+		return xerrors.Errorf("create registry certs directory: %w", err)
+	}
+
+	// Check if certsDir is a file.
+	fileInfo, err := fs.Stat(certsDir)
+	if err != nil {
+		return xerrors.Errorf("stat certs directory/file: %w", err)
+	}
+
+	if !fileInfo.IsDir() {
+		// If it's a file, copy it directly
+		err = copyCertFile(fs, certsDir, filepath.Join(registryCertsDir, "ca.crt"))
+		if err != nil {
+			return xerrors.Errorf("copy cert file: %w", err)
+		}
+		return nil
+	}
+
+	// If it's a directory, copy all cert files in the root of the directory
+	entries, err := afero.ReadDir(fs, certsDir)
+	if err != nil {
+		return xerrors.Errorf("read certs directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		srcPath := filepath.Join(certsDir, entry.Name())
+		dstPath := filepath.Join(registryCertsDir, entry.Name())
+		err = copyCertFile(fs, srcPath, dstPath)
+		if err != nil {
+			return xerrors.Errorf("copy cert file %s: %w", entry.Name(), err)
+		}
+	}
+
+	return nil
+}
+
+func copyCertFile(fs xunix.FS, src, dst string) error {
+	srcFile, err := fs.Open(src)
+	if err != nil {
+		return xerrors.Errorf("open source file: %w", err)
+	}
+	defer srcFile.Close()
+
+	dstFile, err := fs.Create(dst)
+	if err != nil {
+		return xerrors.Errorf("create destination file: %w", err)
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return xerrors.Errorf("copy file contents: %w", err)
+	}
+
+	return nil
+}

--- a/dockerutil/registry.go
+++ b/dockerutil/registry.go
@@ -29,7 +29,7 @@ func WriteCertsForRegistry(ctx context.Context, registryName, certsDir string) e
 	}
 
 	// Ensure the registry certs directory exists.
-	err := fs.MkdirAll(registryCertsDir, 0755)
+	err := fs.MkdirAll(registryCertsDir, 0o755)
 	if err != nil {
 		return xerrors.Errorf("create registry certs directory: %w", err)
 	}

--- a/dockerutil/registry_test.go
+++ b/dockerutil/registry_test.go
@@ -26,7 +26,7 @@ func TestWriteCertsForRegistry(t *testing.T) {
 
 		// Create a test certificate file
 		certContent := []byte("test certificate content")
-		err := afero.WriteFile(fs, "/certs/ca.crt", certContent, 0644)
+		err := afero.WriteFile(fs, "/certs/ca.crt", certContent, 0o644)
 		require.NoError(t, err)
 
 		// Run the function
@@ -48,7 +48,7 @@ func TestWriteCertsForRegistry(t *testing.T) {
 		// Create test certificate files
 		certFiles := []string{"ca.crt", "client.cert", "client.key"}
 		for _, file := range certFiles {
-			err := afero.WriteFile(fs, filepath.Join("/certs", file), []byte("content of "+file), 0644)
+			err := afero.WriteFile(fs, filepath.Join("/certs", file), []byte("content of "+file), 0o644)
 			require.NoError(t, err)
 		}
 
@@ -71,17 +71,17 @@ func TestWriteCertsForRegistry(t *testing.T) {
 
 		// Create an existing registry certs directory
 		registryCertsDir := "/etc/docker/certs.d/test.registry.com"
-		err := fs.MkdirAll(registryCertsDir, 0755)
+		err := fs.MkdirAll(registryCertsDir, 0o755)
 		require.NoError(t, err)
 
 		// Create a file in the existing directory
 		existingContent := []byte("existing certificate content")
-		err = afero.WriteFile(fs, filepath.Join(registryCertsDir, "existing.crt"), existingContent, 0644)
+		err = afero.WriteFile(fs, filepath.Join(registryCertsDir, "existing.crt"), existingContent, 0o644)
 		require.NoError(t, err)
 
 		// Create a test certificate file in the source directory
 		certContent := []byte("new certificate content")
-		err = afero.WriteFile(fs, "/certs/ca.crt", certContent, 0644)
+		err = afero.WriteFile(fs, "/certs/ca.crt", certContent, 0o644)
 		require.NoError(t, err)
 
 		// Run the function

--- a/dockerutil/registry_test.go
+++ b/dockerutil/registry_test.go
@@ -1,0 +1,100 @@
+package dockerutil_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coder/envbox/dockerutil"
+	"github.com/coder/envbox/xunix"
+	"github.com/coder/envbox/xunix/xunixfake"
+)
+
+func TestWriteCertsForRegistry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("SingleCertFile", func(t *testing.T) {
+		t.Parallel()
+		// Test setup
+		fs := xunixfake.NewMemFS()
+		ctx := xunix.WithFS(context.Background(), fs)
+
+		// Create a test certificate file
+		certContent := []byte("test certificate content")
+		err := afero.WriteFile(fs, "/certs/ca.crt", certContent, 0644)
+		require.NoError(t, err)
+
+		// Run the function
+		err = dockerutil.WriteCertsForRegistry(ctx, "test.registry.com", "/certs/ca.crt")
+		require.NoError(t, err)
+
+		// Check the result
+		copiedContent, err := afero.ReadFile(fs, "/etc/docker/certs.d/test.registry.com/ca.crt")
+		require.NoError(t, err)
+		assert.Equal(t, certContent, copiedContent)
+	})
+
+	t.Run("MultipleCertFiles", func(t *testing.T) {
+		t.Parallel()
+		// Test setup
+		fs := xunixfake.NewMemFS()
+		ctx := xunix.WithFS(context.Background(), fs)
+
+		// Create test certificate files
+		certFiles := []string{"ca.crt", "client.cert", "client.key"}
+		for _, file := range certFiles {
+			err := afero.WriteFile(fs, filepath.Join("/certs", file), []byte("content of "+file), 0644)
+			require.NoError(t, err)
+		}
+
+		// Run the function
+		err := dockerutil.WriteCertsForRegistry(ctx, "test.registry.com", "/certs")
+		require.NoError(t, err)
+
+		// Check the results
+		for _, file := range certFiles {
+			copiedContent, err := afero.ReadFile(fs, filepath.Join("/etc/docker/certs.d/test.registry.com", file))
+			require.NoError(t, err)
+			assert.Equal(t, []byte("content of "+file), copiedContent)
+		}
+	})
+	t.Run("ExistingRegistryCertsDir", func(t *testing.T) {
+		t.Parallel()
+		// Test setup
+		fs := xunixfake.NewMemFS()
+		ctx := xunix.WithFS(context.Background(), fs)
+
+		// Create an existing registry certs directory
+		registryCertsDir := "/etc/docker/certs.d/test.registry.com"
+		err := fs.MkdirAll(registryCertsDir, 0755)
+		require.NoError(t, err)
+
+		// Create a file in the existing directory
+		existingContent := []byte("existing certificate content")
+		err = afero.WriteFile(fs, filepath.Join(registryCertsDir, "existing.crt"), existingContent, 0644)
+		require.NoError(t, err)
+
+		// Create a test certificate file in the source directory
+		certContent := []byte("new certificate content")
+		err = afero.WriteFile(fs, "/certs/ca.crt", certContent, 0644)
+		require.NoError(t, err)
+
+		// Run the function
+		err = dockerutil.WriteCertsForRegistry(ctx, "test.registry.com", "/certs")
+		require.NoError(t, err)
+
+		// Check that the existing file was not modified
+		existingFileContent, err := afero.ReadFile(fs, filepath.Join(registryCertsDir, "existing.crt"))
+		require.NoError(t, err)
+		assert.Equal(t, existingContent, existingFileContent)
+
+		// Check that the new file was not copied
+		_, err = fs.Stat(filepath.Join(registryCertsDir, "ca.crt"))
+		assert.True(t, os.IsNotExist(err), "New certificate file should not have been copied")
+	})
+}

--- a/integration/integrationtest/coder.go
+++ b/integration/integrationtest/coder.go
@@ -31,6 +31,12 @@ func (b *BuildLogRecorder) ContainsLog(l string) bool {
 	return false
 }
 
+func (b *BuildLogRecorder) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.logs)
+}
+
 func (b *BuildLogRecorder) append(log string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/integration/integrationtest/docker.go
+++ b/integration/integrationtest/docker.go
@@ -55,10 +55,11 @@ type CreateDockerCVMConfig struct {
 	InnerEnvFilter  []string
 	Envs            []string
 
-	OuterMounts []docker.HostMount
-	AddFUSE     bool
-	AddTUN      bool
-	CPUs        int
+	OuterMounts   []docker.HostMount
+	AddFUSE       bool
+	AddTUN        bool
+	CPUs          int
+	ExpectFailure bool
 }
 
 func (c CreateDockerCVMConfig) validate(t *testing.T) {
@@ -71,13 +72,6 @@ func (c CreateDockerCVMConfig) validate(t *testing.T) {
 	if c.Username == "" {
 		t.Fatalf("a username must be provided")
 	}
-}
-
-type CoderdOptions struct {
-	TLSEnable    bool
-	TLSCert      string
-	TLSKey       string
-	DefaultImage string
 }
 
 // RunEnvbox runs envbox, it returns once the inner container has finished
@@ -109,9 +103,15 @@ func RunEnvbox(t *testing.T, pool *dockertest.Pool, conf *CreateDockerCVMConfig)
 		host.ExtraHosts = []string{"host.docker.internal:host-gateway"}
 	})
 	require.NoError(t, err)
-	// t.Cleanup(func() { _ = pool.Purge(resource) })
 
-	waitForCVM(t, pool, resource)
+	t.Cleanup(func() {
+		if !t.Failed() {
+			_ = pool.Purge(resource)
+		}
+	})
+
+	success := waitForCVM(t, pool, resource)
+	require.Equal(t, success, !conf.ExpectFailure, "expected success=%v but detected %v", !conf.ExpectFailure, success)
 
 	return resource
 }
@@ -203,13 +203,13 @@ func WaitForCVMDocker(t *testing.T, pool *dockertest.Pool, resource *dockertest.
 }
 
 // waitForCVM waits for the inner container to spin up.
-func waitForCVM(t *testing.T, pool *dockertest.Pool, resource *dockertest.Resource) {
+func waitForCVM(t *testing.T, pool *dockertest.Pool, resource *dockertest.Resource) bool {
 	t.Helper()
 
 	rd, wr := io.Pipe()
 	defer rd.Close()
 	defer wr.Close()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()
 	go func() {
 		defer wr.Close()
@@ -245,11 +245,13 @@ func waitForCVM(t *testing.T, pool *dockertest.Pool, resource *dockertest.Resour
 		}
 
 		if blog.Type == buildlog.JSONLogTypeError {
-			t.Fatalf("envbox failed (%s)", blog.Output)
+			t.Logf("envbox failed (%s)", blog.Output)
+			return false
 		}
 	}
 	require.NoError(t, scanner.Err())
 	require.True(t, finished, "unexpected logger exit")
+	return true
 }
 
 type ExecConfig struct {
@@ -402,6 +404,12 @@ func RunLocalDockerRegistry(t testing.TB, pool *dockertest.Pool, conf RegistryCo
 		}
 	})
 	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if !t.Failed() {
+			_ = pool.Purge(resource)
+		}
+	})
 
 	host := net.JoinHostPort("0.0.0.0", conf.TLSPort)
 	url := fmt.Sprintf("https://%s/v2/_catalog", host)

--- a/integration/integrationtest/docker.go
+++ b/integration/integrationtest/docker.go
@@ -111,7 +111,7 @@ func RunEnvbox(t *testing.T, pool *dockertest.Pool, conf *CreateDockerCVMConfig)
 	})
 
 	success := waitForCVM(t, pool, resource)
-	require.Equal(t, success, !conf.ExpectFailure, "expected success=%v but detected %v", !conf.ExpectFailure, success)
+	require.Equal(t, !conf.ExpectFailure, success, "expected success=%v but detected %v", !conf.ExpectFailure, success)
 
 	return resource
 }

--- a/xunix/xunixfake/fs.go
+++ b/xunix/xunixfake/fs.go
@@ -14,6 +14,13 @@ type FileOwner struct {
 	GID int
 }
 
+func NewMemFS() *MemFS {
+	return &MemFS{
+		MemMapFs: &afero.MemMapFs{},
+		Owner:    map[string]FileOwner{},
+	}
+}
+
 type MemFS struct {
 	*afero.MemMapFs
 	Owner map[string]FileOwner


### PR DESCRIPTION
This is the second part of the delivery that provides support for copying certs into the directory `dockerd` checks when pulling an image from a registry. 

