### PR TITLE
fix: parse image auth config correctly

### DIFF
--- a/cli/docker_test.go
+++ b/cli/docker_test.go
@@ -384,13 +384,13 @@ func TestDocker(t *testing.T) {
 		t.Parallel()
 
 		ctx, cmd := clitest.New(t, "docker",
-			"--image=ubuntu",
+			"--image=us.gcr.io/ubuntu",
 			"--username=root",
 			"--agent-token=hi",
 			fmt.Sprintf("--image-secret=%s", rawDockerAuth),
 		)
 
-		raw := []byte(`{"username":"_json_key","password":"{\"type\": \"service_account\", \"project_id\": \"some-test\", \"private_key_id\": \"blahblah\", \"private_key\": \"-----BEGIN PRIVATE KEY-----mykey-----END PRIVATE KEY-----\", \"client_email\": \"test@test.iam.gserviceaccount.com\", \"client_id\": \"123\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"https://oauth2.googleapis.com/token\", \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\", \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/test.iam.gserviceaccount.com\" }","auth":"X2pzb25fa2V5OnsKCgkidHlwZSI6ICJzZXJ2aWNlX2FjY291bnQiLAoJInByb2plY3RfaWQiOiAic29tZS10ZXN0IiwKCSJwcml2YXRlX2tleV9pZCI6ICJibGFoYmxhaCIsCgkicHJpdmF0ZV9rZXkiOiAiLS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCm15a2V5LS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQoiLAoJImNsaWVudF9lbWFpbCI6ICJ0ZXN0QHRlc3QuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLAoJImNsaWVudF9pZCI6ICIxMjMiLAoJImF1dGhfdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi9hdXRoIiwKCSJ0b2tlbl91cmkiOiAiaHR0cHM6Ly9vYXV0aDIuZ29vZ2xlYXBpcy5jb20vdG9rZW4iLAoJImF1dGhfcHJvdmlkZXJfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3d3dy5nb29nbGVhcGlzLmNvbS9vYXV0aDIvdjEvY2VydHMiLAoJImNsaWVudF94NTA5X2NlcnRfdXJsIjogImh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL3JvYm90L3YxL21ldGFkYXRhL3g1MDkvdGVzdC5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIKfQo=","email":"test@test.iam.gserviceaccount.com"}`)
+		raw := []byte(`{"username":"_json_key","password":"{\"type\": \"service_account\", \"project_id\": \"some-test\", \"private_key_id\": \"blahblah\", \"private_key\": \"-----BEGIN PRIVATE KEY-----mykey-----END PRIVATE KEY-----\", \"client_email\": \"test@test.iam.gserviceaccount.com\", \"client_id\": \"123\", \"auth_uri\": \"https://accounts.google.com/o/oauth2/auth\", \"token_uri\": \"https://oauth2.googleapis.com/token\", \"auth_provider_x509_cert_url\": \"https://www.googleapis.com/oauth2/v1/certs\", \"client_x509_cert_url\": \"https://www.googleapis.com/robot/v1/metadata/x509/test.iam.gserviceaccount.com\" }"}`)
 		authB64 := base64.URLEncoding.EncodeToString(raw)
 
 		client := clitest.DockerClient(t, ctx)

--- a/dockerutil/client.go
+++ b/dockerutil/client.go
@@ -89,5 +89,4 @@ func parseConfig(cfg dockercfg.Config, registry string) (AuthConfig, error) {
 	}
 
 	return AuthConfig{}, xerrors.Errorf("no auth config found for registry %s: %w", registry, os.ErrNotExist)
-
 }

--- a/dockerutil/client.go
+++ b/dockerutil/client.go
@@ -68,7 +68,6 @@ func AuthConfigFromString(raw string, reg string) (AuthConfig, error) {
 }
 
 func parseConfig(cfg dockercfg.Config, registry string) (AuthConfig, error) {
-
 	hostname := dockercfg.ResolveRegistryHost(registry)
 
 	username, secret, err := cfg.GetRegistryCredentials(hostname)

--- a/dockerutil/client_test.go
+++ b/dockerutil/client_test.go
@@ -11,6 +11,7 @@ import (
 func TestAuthConfigFromString(t *testing.T) {
 	t.Parallel()
 
+	//nolint:gosec // this is a test
 	creds := `{ "auths": { "docker.registry.test": { "auth": "Zm9vQGJhci5jb206YWJjMTIz" } } }`
 	expectedUsername := "foo@bar.com"
 	expectedPassword := "abc123"

--- a/dockerutil/client_test.go
+++ b/dockerutil/client_test.go
@@ -11,13 +11,31 @@ import (
 func TestAuthConfigFromString(t *testing.T) {
 	t.Parallel()
 
-	//nolint:gosec // this is a test
-	creds := `{ "auths": { "docker.registry.test": { "auth": "Zm9vQGJhci5jb206YWJjMTIz" } } }`
-	expectedUsername := "foo@bar.com"
-	expectedPassword := "abc123"
+	t.Run("Auth", func(t *testing.T) {
+		t.Parallel()
 
-	cfg, err := dockerutil.AuthConfigFromString(creds, "docker.registry.test")
-	require.NoError(t, err)
-	require.Equal(t, expectedUsername, cfg.Username)
-	require.Equal(t, expectedPassword, cfg.Password)
+		//nolint:gosec // this is a test
+		creds := `{ "auths": { "docker.registry.test": { "auth": "Zm9vQGJhci5jb206YWJjMTIz" } } }`
+		expectedUsername := "foo@bar.com"
+		expectedPassword := "abc123"
+
+		cfg, err := dockerutil.AuthConfigFromString(creds, "docker.registry.test")
+		require.NoError(t, err)
+		require.Equal(t, expectedUsername, cfg.Username)
+		require.Equal(t, expectedPassword, cfg.Password)
+	})
+
+	t.Run("UsernamePassword", func(t *testing.T) {
+		t.Parallel()
+
+		//nolint:gosec // this is a test
+		creds := `{ "auths": { "docker.registry.test": { "username": "foobarbaz", "password": "123abc" } } }`
+		expectedUsername := "foobarbaz"
+		expectedPassword := "123abc"
+
+		cfg, err := dockerutil.AuthConfigFromString(creds, "docker.registry.test")
+		require.NoError(t, err)
+		require.Equal(t, expectedUsername, cfg.Username)
+		require.Equal(t, expectedPassword, cfg.Password)
+	})
 }

--- a/dockerutil/client_test.go
+++ b/dockerutil/client_test.go
@@ -3,14 +3,15 @@ package dockerutil_test
 import (
 	"testing"
 
-	"github.com/coder/envbox/dockerutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/coder/envbox/dockerutil"
 )
 
 func TestAuthConfigFromString(t *testing.T) {
 	t.Parallel()
 
-	creds := `{ "auths": { "docker.registry.test": { "auth": "Zm9vQGJhci5jb206YWJjMTIzCg==" } } }`
+	creds := `{ "auths": { "docker.registry.test": { "auth": "Zm9vQGJhci5jb206YWJjMTIz" } } }`
 	expectedUsername := "foo@bar.com"
 	expectedPassword := "abc123"
 

--- a/dockerutil/client_test.go
+++ b/dockerutil/client_test.go
@@ -1,0 +1,21 @@
+package dockerutil_test
+
+import (
+	"testing"
+
+	"github.com/coder/envbox/dockerutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthConfigFromString(t *testing.T) {
+	t.Parallel()
+
+	creds := `{ "auths": { "docker.registry.test": { "auth": "Zm9vQGJhci5jb206YWJjMTIzCg==" } } }`
+	expectedUsername := "foo@bar.com"
+	expectedPassword := "abc123"
+
+	cfg, err := dockerutil.AuthConfigFromString(creds, "docker.registry.test")
+	require.NoError(t, err)
+	require.Equal(t, expectedUsername, cfg.Username)
+	require.Equal(t, expectedPassword, cfg.Password)
+}

--- a/integration/integrationtest/docker.go
+++ b/integration/integrationtest/docker.go
@@ -549,6 +549,7 @@ func pushLocalImage(t *testing.T, pool *dockertest.Pool, opts pushOptions) Regis
 	// Idk what to tell you but the pool.Client.PushImage
 	// function is bugged or I'm just dumb...
 	image := fmt.Sprintf("%s:%s/%s:%s", registryHost, port, name, tag)
+	//nolint:gosec
 	cmd := exec.Command("docker", "--config", opts.ConfigDir, "push", image)
 	cmd.Stderr = tw
 	cmd.Stdout = tw


### PR DESCRIPTION
This PR fixes authentication not working if `Username, Password` fields are omitted in favor of an `Auth` field. The `Auth` field can be a base64 encoded concatenation of the two. This PR also adds logic to existing integration tests to ensure authenticated pulls work as expected.

fixes https://github.com/coder/envbox/issues/102