### PR TITLE
fix(xunix): also mount shared symlinked shared object files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,12 @@ fmt/go:
 .PHONY: fmt/md
 fmt/md:
 	go run github.com/Kunde21/markdownfmt/v3/cmd/markdownfmt@v3.1.0 -w ./README.md
+
+
+.PHONY: test
+test:
+	go test -v -count=1 ./...
+
+.PHONY: test-integration
+test-integration:
+	go test -v -count=1 -tags=integration ./integration/

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ fmt/go:
 fmt/md:
 	go run github.com/Kunde21/markdownfmt/v3/cmd/markdownfmt@v3.1.0 -w ./README.md
 
-
 .PHONY: test
 test:
 	go test -v -count=1 ./...

--- a/xunix/gpu.go
+++ b/xunix/gpu.go
@@ -17,9 +17,10 @@ import (
 )
 
 var (
-	gpuMountRegex = regexp.MustCompile("(?i)(nvidia|vulkan|cuda)")
-	gpuExtraRegex = regexp.MustCompile("(?i)(libgl|nvidia|vulkan|cuda)")
-	gpuEnvRegex   = regexp.MustCompile("(?i)nvidia")
+	gpuMountRegex     = regexp.MustCompile("(?i)(nvidia|vulkan|cuda)")
+	gpuExtraRegex     = regexp.MustCompile("(?i)(libgl|nvidia|vulkan|cuda)")
+	gpuEnvRegex       = regexp.MustCompile("(?i)nvidia")
+	sharedObjectRegex = regexp.MustCompile(`\.so(\.[0-9\.]+)?$`)
 )
 
 func GPUEnvs(ctx context.Context) []string {
@@ -103,7 +104,7 @@ func usrLibGPUs(ctx context.Context, log slog.Logger, usrLibDir string) ([]mount
 				return nil
 			}
 
-			if filepath.Ext(path) != ".so" || !gpuExtraRegex.MatchString(path) {
+			if !sharedObjectRegex.MatchString(path) || !gpuExtraRegex.MatchString(path) {
 				return nil
 			}
 

--- a/xunix/gpu_test.go
+++ b/xunix/gpu_test.go
@@ -56,13 +56,13 @@ func TestGPUs(t *testing.T) {
 			expectedUsrLibFiles = []string{
 				filepath.Join(usrLibMountpoint, "nvidia", "libglxserver_nvidia.so"),
 				filepath.Join(usrLibMountpoint, "libnvidia-ml.so"),
+				filepath.Join(usrLibMountpoint, "nvidia", "libglxserver_nvidia.so.1"),
 			}
 
 			// fakeUsrLibFiles are files that should be written to the "mounted"
 			// /usr/lib directory. It includes files that shouldn't be returned.
 			fakeUsrLibFiles = append([]string{
 				filepath.Join(usrLibMountpoint, "libcurl-gnutls.so"),
-				filepath.Join(usrLibMountpoint, "nvidia", "libglxserver_nvidia.so.1"),
 			}, expectedUsrLibFiles...)
 		)
 
@@ -98,7 +98,7 @@ func TestGPUs(t *testing.T) {
 		devices, binds, err := xunix.GPUs(ctx, log, usrLibMountpoint)
 		require.NoError(t, err)
 		require.Len(t, devices, 2, "unexpected 2 nvidia devices")
-		require.Len(t, binds, 3, "expected 4 nvidia binds")
+		require.Len(t, binds, 4, "expected 4 nvidia binds")
 		require.Contains(t, binds, mount.MountPoint{
 			Device: "/dev/sda1",
 			Path:   "/usr/local/nvidia",


### PR DESCRIPTION
# Summary

Relates to https://github.com/coder/envbox/issues/111

Container runtimes like the NVIDIA container toolkit will inject library dependencies inside containers they create. More recent versions of these runtimes / operators appear to mount the libraries with `$library.so.$NVIDIA_DRIVER_VERISON` and symlink `$library.so` to those locations.

Example:
```
lrwxrwxrwx  1 root root       32 Jan 26 20:09 libnvidia-allocator.so.1 -> libnvidia-allocator.so.550.90.07
-rwxr-xr-x  1 root root   168776 Dec 23 16:41 libnvidia-allocator.so.550.90.07
lrwxrwxrwx  1 root root       26 Jan 26 20:09 libnvidia-cfg.so.1 -> libnvidia-cfg.so.550.90.07
-rwxr-xr-x  1 root root   398968 Dec 23 16:41 libnvidia-cfg.so.550.90.07
-rwxr-xr-x  1 root root 43659040 Dec 23 16:41 libnvidia-gpucomp.so.550.90.07
lrwxrwxrwx  1 root root       25 Jan 26 20:09 libnvidia-ml.so.1 -> libnvidia-ml.so.550.90.07
-rwxr-xr-x  1 root root  2078360 Dec 23 16:41 libnvidia-ml.so.550.90.07
lrwxrwxrwx  1 root root       27 Jan 26 20:09 libnvidia-nvvm.so.4 -> libnvidia-nvvm.so.550.90.07
-rwxr-xr-x  1 root root 86842616 Dec 23 16:41 libnvidia-nvvm.so.550.90.07
lrwxrwxrwx  1 root root       29 Jan 26 20:09 libnvidia-opencl.so.1 -> libnvidia-opencl.so.550.90.07
-rwxr-xr-x  1 root root 23494344 Dec 23 16:41 libnvidia-opencl.so.550.90.07
-rwxr-xr-x  1 root root    10176 Dec 23 16:41 libnvidia-pkcs11-openssl3.so.550.90.07
-rwxr-xr-x  1 root root    10168 Dec 23 16:41 libnvidia-pkcs11.so.550.90.07
lrwxrwxrwx  1 root root       37 Jan 26 20:09 libnvidia-ptxjitcompiler.so.1 -> libnvidia-ptxjitcompiler.so.550.90.07
-rwxr-xr-x  1 root root 28674464 Dec 23 16:41 libnvidia-ptxjitcompiler.so.550.90.07
```

For more details, see here: https://gist.github.com/johnstcn/1caae2e79eea8788dc7f31e3db4326eb

Changes made:

- Relaxes the restriction regarding which mounts are passed inside the inner container. Before only files ending with `*.so` were mounted inside the inner container. Now, all files matching `.*.so(\.[0-9\.]+)?` are included.
- Updates README to add information regarding some of the issues I ran into (such as `cgroupns=private`)
- Updates integration tests to pass on cgroupv2-enabled host

# Environment
- Ubuntu 22.04.5 with kernel 6.8.0-51-generic
- No `shiftfs` installed
- Laptop with NVIDIA RTX 3060 Laptop GPU
- Docker 27.5.1
- NVIDIA driver version 550.90.07 (from `NVIDIA-Linux-x86_64-550.90.07.run`)
- NVIDIA container toolkit version 1.17.4-1 (from NVIDIA APT repo)

# Before

```
docker run -it --rm -v /tmp/envbox/docker:/var/lib/coder/docker -v /tmp/envbox/containers:/var/lib/coder/containers -v /tmp/envbox/sysbox:/var/lib/sysbox -v /tmp/envbox/docker:/var/lib/docker -v /usr/src:/usr/src:ro -v /lib/modules:/lib/modules:ro --privileged --cgroupns=host -e CODER_INNER_IMAGE=nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2 -e CODER_INNER_USERNAME=root -e CODER_ADD_GPU=true -e CODER_USR_LIB_DIR=/usr/lib --runtime=nvidia --gpus=all ghcr.io/coder/envbox:0.6.2 bash

root@container:/# /envbox docker &
<snip>
root@container:/# docker exec -it workspace_cvm bash

root@workspace_cvm:/# nvidia-smi
NVIDIA-SMI couldn't find libnvidia-ml.so library in your system. Please make sure that the NVIDIA Display Driver is properly installed and present in your system.
Please also try adding directory that contains libnvidia-ml.so to your system PATH.

root@workspace_cvm:/# /tmp/vectorAdd 
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Failed to launch vectorAdd kernel (error code PTX JIT compiler library not found)!
```


# After

```
docker run -it --rm -v /tmp/envbox/docker:/var/lib/coder/docker -v /tmp/envbox/containers:/var/lib/coder/containers -v /tmp/envbox/sysbox:/var/lib/sysbox -v /tmp/envbox/docker:/var/lib/docker -v /usr/src:/usr/src:ro -v /lib/modules:/lib/modules:ro --privileged --cgroupns=host -e CODER_INNER_IMAGE=nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2 -e CODER_INNER_USERNAME=root -e CODER_ADD_GPU=true -e CODER_USR_LIB_DIR=/usr/lib --runtime=nvidia --gpus=all envbox:latest bash

root@container:/# /envbox docker &
<snip>
root@container:/# docker exec -it workspace_cvm bash

root@workspace_cvm:/# nvidia-smi
Sun Jan 26 22:18:09 2025       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.90.07              Driver Version: 550.90.07      CUDA Version: 12.4     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 3060 ...    Off |   00000000:01:00.0 Off |                  N/A |
| N/A   50C    P8             15W /   90W |       2MiB /   6144MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+

root@workspace_cvm:/# /tmp/vectorAdd
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

```
