### PR TITLE
fix(dockerutil): correct usrLibMultiarchDir

### DIFF
--- a/dockerutil/image.go
+++ b/dockerutil/image.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"cdr.dev/slog"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"golang.org/x/xerrors"
+
+	"cdr.dev/slog"
 
 	"github.com/coder/envbox/buildlog"
 	"github.com/coder/envbox/xunix"

--- a/dockerutil/image_linux_amd64.go
+++ b/dockerutil/image_linux_amd64.go
@@ -2,4 +2,4 @@ package dockerutil
 
 // usrLibMultiarchDir is defined for arm64 and amd64 architectures.
 // Envbox is not published for other architectures.
-var usrLibMultiarchDir = "/usr/lib/aarch64-linux-gnu"
+var usrLibMultiarchDir = "/usr/lib/x86_64-linux-gnu"

--- a/dockerutil/image_linux_arm64.go
+++ b/dockerutil/image_linux_arm64.go
@@ -2,4 +2,4 @@ package dockerutil
 
 // usrLibMultiarchDir is defined for arm64 and amd64 architectures.
 // Envbox is not published for other architectures.
-var usrLibMultiarchDir = "/usr/lib/x86_64-linux-gnu"
+var usrLibMultiarchDir = "/usr/lib/aarch64-linux-gnu"


### PR DESCRIPTION
Fixes an error in the definition of `usrLibMultiarchDir` in #127 