### PR TITLE
fix(xunix): improve handling of gpu library mounts

### DIFF
--- a/integration/gpu_test.go
+++ b/integration/gpu_test.go
@@ -69,6 +69,12 @@ func TestDocker_Nvidia(t *testing.T) {
 		if !assert.NoError(t, err, "failed to run dnf in the inner container") {
 			t.Logf("dnf output:\n%s", strings.TrimSpace(out))
 		}
+
+		// Make sure libglib.so is not present in the inner container.
+		out, err = execContainerCmd(ctx, t, ctID, "docker", "exec", "workspace_cvm", "ls", "-1", "/usr/lib/x86_64-linux-gnu/libglib*")
+		// An error is expected here.
+		assert.Error(t, err, "libglib should not be present in the inner container")
+		assert.Contains(t, out, "No such file or directory", "libglib should not be present in the inner container")
 	})
 
 	t.Run("InnerUsrLibDirOverride", func(t *testing.T) {

--- a/integration/integrationtest/docker.go
+++ b/integration/integrationtest/docker.go
@@ -42,6 +42,9 @@ const (
 	UbuntuImage = "gcr.io/coder-dev-1/sreya/ubuntu-coder"
 	// Redhat UBI9 image as of 2025-03-05
 	RedhatImage = "registry.access.redhat.com/ubi9/ubi:9.5"
+	// CUDASampleImage is a CUDA sample image from NVIDIA's container registry.
+	// It contains a binary /tmp/vectorAdd which can be run to test the CUDA setup.
+	CUDASampleImage = "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda10.2"
 
 	// RegistryImage is used to assert that we add certs
 	// correctly to the docker daemon when pulling an image

--- a/xunix/gpu.go
+++ b/xunix/gpu.go
@@ -18,9 +18,10 @@ import (
 )
 
 var (
-	gpuMountRegex = regexp.MustCompile(`(?i)(nvidia|vulkan|cuda)`)
-	gpuExtraRegex = regexp.MustCompile(`(?i)(libgl(e|sx|\.)|nvidia|vulkan|cuda)`)
-	gpuEnvRegex   = regexp.MustCompile(`(?i)nvidia`)
+	gpuMountRegex     = regexp.MustCompile(`(?i)(nvidia|vulkan|cuda)`)
+	gpuExtraRegex     = regexp.MustCompile(`(?i)(libgl(e|sx|\.)|nvidia|vulkan|cuda)`)
+	gpuEnvRegex       = regexp.MustCompile(`(?i)nvidia`)
+	sharedObjectRegex = regexp.MustCompile(`\.so(\.[0-9\.]+)?$`)
 )
 
 func GPUEnvs(ctx context.Context) []string {
@@ -122,6 +123,10 @@ func usrLibGPUs(ctx context.Context, log slog.Logger, usrLibDir string) ([]mount
 			}
 
 			if !gpuExtraRegex.MatchString(path) {
+				return nil
+			}
+
+			if !sharedObjectRegex.MatchString(path) {
 				return nil
 			}
 

--- a/xunix/gpu_test.go
+++ b/xunix/gpu_test.go
@@ -2,10 +2,13 @@ package xunix_test
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/mount-utils"
 
@@ -111,4 +114,104 @@ func TestGPUs(t *testing.T) {
 			})
 		}
 	})
+}
+
+func Test_SameDirSymlinks(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctx = context.Background()
+		// We need to test with a real filesystem as the fake one doesn't
+		// support creating symlinks.
+		tmpDir = t.TempDir()
+		// We do test with the interface though!
+		afs = xunix.GetFS(ctx)
+	)
+
+	// Create some files in the temporary directory.
+	_, err := os.Create(filepath.Join(tmpDir, "file1.real"))
+	require.NoError(t, err, "create file")
+	_, err = os.Create(filepath.Join(tmpDir, "file2.real"))
+	require.NoError(t, err, "create file2")
+	_, err = os.Create(filepath.Join(tmpDir, "file3.real"))
+	require.NoError(t, err, "create file3")
+	_, err = os.Create(filepath.Join(tmpDir, "file4.real"))
+	require.NoError(t, err, "create file4")
+
+	// Create a symlink to the file in the temporary directory.
+	// This needs to be done by the real os package.
+	err = os.Symlink(filepath.Join(tmpDir, "file1.real"), filepath.Join(tmpDir, "file1.link1"))
+	require.NoError(t, err, "create first symlink")
+
+	// Create another symlink to the previous symlink.
+	err = os.Symlink(filepath.Join(tmpDir, "file1.link1"), filepath.Join(tmpDir, "file1.link2"))
+	require.NoError(t, err, "create second symlink")
+
+	// Create a symlink to a file outside of the temporary directory.
+	err = os.MkdirAll(filepath.Join(tmpDir, "dir"), 0o755)
+	require.NoError(t, err, "create dir")
+	// Create a symlink from file2 to inside the dir.
+	err = os.Symlink(filepath.Join(tmpDir, "file2.real"), filepath.Join(tmpDir, "dir", "file2.link1"))
+	require.NoError(t, err, "create dir symlink")
+
+	// Create a symlink with a relative path. To do this, we need to
+	// change the working directory to the temporary directory.
+	oldWorkingDir, err := os.Getwd()
+	require.NoError(t, err, "get working dir")
+	// Change the working directory to the temporary directory.
+	require.NoError(t, os.Chdir(tmpDir), "change working dir")
+	err = os.Symlink(filepath.Join(tmpDir, "file4.real"), "file4.link1")
+	require.NoError(t, err, "create relative symlink")
+	// Change the working directory back to the original.
+	require.NoError(t, os.Chdir(oldWorkingDir), "change working dir back")
+
+	for _, tt := range []struct {
+		name     string
+		expected []string
+	}{
+		{
+			// Two symlinks to the same file.
+			name: "file1.real",
+			expected: []string{
+				filepath.Join(tmpDir, "file1.link1"),
+				filepath.Join(tmpDir, "file1.link2"),
+			},
+		},
+		{
+			// Mid-way in the symlink chain.
+			name: "file1.link1",
+			expected: []string{
+				filepath.Join(tmpDir, "file1.link2"),
+			},
+		},
+		{
+			// End of the symlink chain.
+			name:     "file1.link2",
+			expected: []string{},
+		},
+		{
+			// Symlink to a file outside of the temporary directory.
+			name:     "file2.real",
+			expected: []string{},
+		},
+		{
+			// No symlinks to this file.
+			name:     "file3.real",
+			expected: []string{},
+		},
+		{
+			// One relative symlink.
+			name:     "file4.real",
+			expected: []string{filepath.Join(tmpDir, "file4.link1")},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fullPath := filepath.Join(tmpDir, tt.name)
+			actual, err := xunix.SameDirSymlinks(afs, fullPath)
+			require.NoError(t, err, "find symlink")
+			sort.Strings(actual)
+			assert.Equal(t, tt.expected, actual, "find symlinks %q", tt.name)
+		})
+	}
 }

--- a/xunix/gpu_test.go
+++ b/xunix/gpu_test.go
@@ -111,7 +111,7 @@ func TestGPUs(t *testing.T) {
 		devices, binds, err := xunix.GPUs(ctx, log, usrLibMountpoint)
 		require.NoError(t, err)
 		require.Len(t, devices, 2, "unexpected 2 nvidia devices")
-		require.Len(t, binds, 5, "expected 5 nvidia binds")
+		require.Len(t, binds, 4, "expected 4 nvidia binds")
 		require.Contains(t, binds, mount.MountPoint{
 			Device: "/dev/sda1",
 			Path:   "/usr/local/nvidia",


### PR DESCRIPTION
This PR fixes some issues Bjorn found when testing the changes in #127 as well as some other lingering issues I'd noticed:

1) The nvidia container runtime will mount libraries with the driver version number appended to them, and creates symlinks to those files:

```
root@ad0724e97635:/# ls -l /usr/lib/x86_64-linux-gnu/ | grep -Ei 'libgl|nvidia|vulkan|cuda'
lrwxrwxrwx  1 root root       12 Mar  6 23:19 libcuda.so -> libcuda.so.1
lrwxrwxrwx  1 root root       20 Mar  6 23:19 libcuda.so.1 -> libcuda.so.550.90.07
-rwxr-xr-x  1 root root 28581024 Dec 23 16:41 libcuda.so.550.90.07
lrwxrwxrwx  1 root root       28 Mar  6 23:19 libcudadebugger.so.1 -> libcudadebugger.so.550.90.07
-rwxr-xr-x  1 root root 10524136 Dec 23 16:41 libcudadebugger.so.550.90.07
lrwxrwxrwx  1 root root       32 Mar  6 23:19 libnvidia-allocator.so.1 -> libnvidia-allocator.so.550.90.07
-rwxr-xr-x  1 root root   168776 Dec 23 16:41 libnvidia-allocator.so.550.90.07
lrwxrwxrwx  1 root root       26 Mar  6 23:19 libnvidia-cfg.so.1 -> libnvidia-cfg.so.550.90.07
-rwxr-xr-x  1 root root   398968 Dec 23 16:41 libnvidia-cfg.so.550.90.07
-rwxr-xr-x  1 root root 43659040 Dec 23 16:41 libnvidia-gpucomp.so.550.90.07
lrwxrwxrwx  1 root root       25 Mar  6 23:19 libnvidia-ml.so.1 -> libnvidia-ml.so.550.90.07
-rwxr-xr-x  1 root root  2078360 Dec 23 16:41 libnvidia-ml.so.550.90.07
lrwxrwxrwx  1 root root       27 Mar  6 23:19 libnvidia-nvvm.so.4 -> libnvidia-nvvm.so.550.90.07
-rwxr-xr-x  1 root root 86842616 Dec 23 16:41 libnvidia-nvvm.so.550.90.07
lrwxrwxrwx  1 root root       29 Mar  6 23:19 libnvidia-opencl.so.1 -> libnvidia-opencl.so.550.90.07
-rwxr-xr-x  1 root root 23494344 Dec 23 16:41 libnvidia-opencl.so.550.90.07
-rwxr-xr-x  1 root root    10176 Dec 23 16:41 libnvidia-pkcs11-openssl3.so.550.90.07
-rwxr-xr-x  1 root root    10168 Dec 23 16:41 libnvidia-pkcs11.so.550.90.07
lrwxrwxrwx  1 root root       37 Mar  6 23:19 libnvidia-ptxjitcompiler.so.1 -> libnvidia-ptxjitcompiler.so.550.90.07
-rwxr-xr-x  1 root root 28674464 Dec 23 16:41 libnvidia-ptxjitcompiler.so.550.90.07
```

We had been mounting in the mounts to e.g. `libnvidia-ml.so.550.90.07` but not the symlinks, as those do not show up as mounts:

```
root@ad0724e97635:/# mount | grep -Ei 'libgl|nvidia|vulkan|cuda'
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/bin/nvidia-smi type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/bin/nvidia-debugdump type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/bin/nvidia-persistenced type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/bin/nvidia-cuda-mps-control type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/bin/nvidia-cuda-mps-server type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libcuda.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libcudadebugger.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libnvidia-gpucomp.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libnvidia-allocator.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libnvidia-pkcs11.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libnvidia-pkcs11-openssl3.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.550.90.07 type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/firmware/nvidia/550.90.07/gsp_ga10x.bin type ext4 (ro,nosuid,nodev,relatime)
/dev/mapper/ubuntu--vg-ubuntu--lv on /usr/lib/firmware/nvidia/550.90.07/gsp_tu10x.bin type ext4 (ro,nosuid,nodev,relatime)
udev on /dev/nvidiactl type devtmpfs (ro,nosuid,noexec,relatime,size=32743052k,nr_inodes=8185763,mode=755,inode64)
udev on /dev/nvidia-uvm type devtmpfs (ro,nosuid,noexec,relatime,size=32743052k,nr_inodes=8185763,mode=755,inode64)
udev on /dev/nvidia-uvm-tools type devtmpfs (ro,nosuid,noexec,relatime,size=32743052k,nr_inodes=8185763,mode=755,inode64)
udev on /dev/nvidia0 type devtmpfs (ro,nosuid,noexec,relatime,size=32743052k,nr_inodes=8185763,mode=755,inode64)
```

This modifies the behaviour of `xunix.GPUs` to also return the symlinks to those driver files, so that we also mount them inside the inner container.

2) This is likely an oversight from #123 but appears to also have been present a longer time. `gpuExtraRegex` will search for files matching the expression `(?i)(libgl|nvidia|vulkan|cuda)`. It turns out this will also match `libglib-X.Y.so`. This is something we want to avoid, as it can cause `dnf` to break when running Redhat-based distros in the inner container. Shout out to Bjorn for spotting this! 

> More info: 
> 
> `libglib-2.0.so.0` from my host machine depended on `libpcre.so.3`:
> 
> ```
> $ ldd /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
>         linux-vdso.so.1 (0x00007ffcf7dfa000)
>         libpcre.so.3 => /lib/x86_64-linux-gnu/libpcre.so.3 (0x000079c5fc7ee000)
>         libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000079c5fc707000)
>         libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000079c5fc400000)
>         /lib64/ld-linux-x86-64.so.2 (0x000079c5fc9a8000)
> ```
> 
> The system python in the inner image appears to have been trying to pick it up and failing due to the missing dependency:
> 
> ```
> [root@workspacecvm /]# dnf update
> Traceback (most recent call last):
>   File "/usr/bin/dnf", line 61, in <module>
>     from dnf.cli import main
>   File "/usr/lib/python3.9/site-packages/dnf/__init__.py", line 30, in <module>
>     import dnf.base
>   File "/usr/lib/python3.9/site-packages/dnf/base.py", line 29, in <module>
>     import libdnf.transaction
>   File "/usr/lib64/python3.9/site-packages/libdnf/__init__.py", line 12, in <module>
>     from . import conf
>   File "/usr/lib64/python3.9/site-packages/libdnf/conf.py", line 13, in <module>
>     from . import _conf
> ImportError: libpcre.so.3: cannot open shared object file: No such file or directory
> ```
> 


3. Also adds more GPU integration tests, including one that uses the sample CUDA image from NVidia.

NOTE: as these integration tests do not run automatically in CI, you will need to run them manually on a physical machine that has the NVidia container runtime installed:

```
CODER_TEST_INTEGRATION=1 go test -v -count=1 ./integration -test.run='^TestDocker_Nvidia/'
```