### PR TITLE
chore: update runners to Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,7 @@ jobs:
         run: go test ./...
 
   integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
       - name: Install  dependencies
@@ -165,7 +165,7 @@ jobs:
         run: go test -tags=integration ./...
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -245,7 +245,7 @@ jobs:
         uses: github/codeql-action/analyze@v2
 
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Docker Login


### PR DESCRIPTION
- Support for 20.04 ends on 04/15/25.