### PR TITLE
fix: provide backwards compatibility for image secrets without a hostname

### DIFF
--- a/dockerutil/client.go
+++ b/dockerutil/client.go
@@ -82,16 +82,39 @@ func parseConfig(cfg dockercfg.Config, reg string) (AuthConfig, error) {
 	}
 
 	if secret != "" {
-		if username == "" {
-			return AuthConfig{
-				IdentityToken: secret,
-			}, nil
-		}
-		return AuthConfig{
-			Username: username,
-			Password: secret,
-		}, nil
+		return toAuthConfig(username, secret), nil
 	}
 
+	// // This to preserve backwards compatibility with older variants of envbox
+	// // that didn't mandate a hostname key in the config file. We just take the
+	// // first valid auth config we find and use that.
+	// for _, auth := range cfg.AuthConfigs {
+	// 	if auth.IdentityToken != "" {
+	// 		return toAuthConfig("", auth.IdentityToken), nil
+	// 	}
+
+	// 	if auth.Username != "" && auth.Password != "" {
+	// 		return toAuthConfig(auth.Username, auth.Password), nil
+	// 	}
+
+	// 	username, secret, err = dockercfg.DecodeBase64Auth(auth)
+	// 	if err == nil && secret != "" {
+	// 		return toAuthConfig(username, secret), nil
+	// 	}
+	// 	// Invalid auth config, skip it.
+	// }
+
 	return AuthConfig{}, xerrors.Errorf("no auth config found for registry %s: %w", reg, os.ErrNotExist)
+}
+
+func toAuthConfig(username, secret string) AuthConfig {
+	if username == "" {
+		return AuthConfig{
+			IdentityToken: secret,
+		}
+	}
+	return AuthConfig{
+		Username: username,
+		Password: secret,
+	}
 }

--- a/dockerutil/client.go
+++ b/dockerutil/client.go
@@ -85,24 +85,24 @@ func parseConfig(cfg dockercfg.Config, reg string) (AuthConfig, error) {
 		return toAuthConfig(username, secret), nil
 	}
 
-	// // This to preserve backwards compatibility with older variants of envbox
-	// // that didn't mandate a hostname key in the config file. We just take the
-	// // first valid auth config we find and use that.
-	// for _, auth := range cfg.AuthConfigs {
-	// 	if auth.IdentityToken != "" {
-	// 		return toAuthConfig("", auth.IdentityToken), nil
-	// 	}
+	// This to preserve backwards compatibility with older variants of envbox
+	// that didn't mandate a hostname key in the config file. We just take the
+	// first valid auth config we find and use that.
+	for _, auth := range cfg.AuthConfigs {
+		if auth.IdentityToken != "" {
+			return toAuthConfig("", auth.IdentityToken), nil
+		}
 
-	// 	if auth.Username != "" && auth.Password != "" {
-	// 		return toAuthConfig(auth.Username, auth.Password), nil
-	// 	}
+		if auth.Username != "" && auth.Password != "" {
+			return toAuthConfig(auth.Username, auth.Password), nil
+		}
 
-	// 	username, secret, err = dockercfg.DecodeBase64Auth(auth)
-	// 	if err == nil && secret != "" {
-	// 		return toAuthConfig(username, secret), nil
-	// 	}
-	// 	// Invalid auth config, skip it.
-	// }
+		username, secret, err = dockercfg.DecodeBase64Auth(auth)
+		if err == nil && secret != "" {
+			return toAuthConfig(username, secret), nil
+		}
+		// Invalid auth config, skip it.
+	}
 
 	return AuthConfig{}, xerrors.Errorf("no auth config found for registry %s: %w", reg, os.ErrNotExist)
 }


### PR DESCRIPTION
- https://github.com/coder/envbox/pull/103 introduced a hostname requirement in the auth config provided. This subtly broke some users.