### PR TITLE
feat: add support for additional device paths in GPU detection

### DIFF
--- a/cli/docker.go
+++ b/cli/docker.go
@@ -107,6 +107,7 @@ var (
 	EnvDebug                = "CODER_DEBUG"
 	EnvDisableIDMappedMount = "CODER_DISABLE_IDMAPPED_MOUNT"
 	EnvExtraCertsPath       = "CODER_EXTRA_CERTS_PATH"
+	EnvAdditionalDevices    = "CODER_ADDITIONAL_DEVICES"
 )
 
 var envboxPrivateMounts = map[string]struct{}{
@@ -146,6 +147,7 @@ type flags struct {
 	memory               int
 	disableIDMappedMount bool
 	extraCertsPath       string
+	additionalDevices    string
 
 	// Test flags.
 	noStartupLogs bool
@@ -443,6 +445,7 @@ func dockerCmd() *cobra.Command {
 	cliflag.IntVarP(cmd.Flags(), &flags.memory, "memory", "", EnvMemory, 0, "Max memory to allocate to the inner container in bytes.")
 	cliflag.BoolVarP(cmd.Flags(), &flags.disableIDMappedMount, "disable-idmapped-mount", "", EnvDisableIDMappedMount, false, "Disable idmapped mounts in sysbox. Note that you may need an alternative (e.g. shiftfs).")
 	cliflag.StringVarP(cmd.Flags(), &flags.extraCertsPath, "extra-certs-path", "", EnvExtraCertsPath, "", "The path to a directory or file containing extra CA certificates.")
+	cliflag.StringVarP(cmd.Flags(), &flags.additionalDevices, "additional-devices", "", EnvAdditionalDevices, "", "Comma-separated list of additional device paths to append to the mounts list when detecting GPUs.")
 
 	// Test flags.
 	cliflag.BoolVarP(cmd.Flags(), &flags.noStartupLogs, "no-startup-log", "", "", false, "Do not log startup logs. Useful for testing.")
@@ -665,7 +668,7 @@ func runDockerCVM(ctx context.Context, log slog.Logger, client dockerutil.Client
 	}
 
 	if flags.addGPU {
-		devs, binds, err := xunix.GPUs(ctx, log, flags.hostUsrLibDir)
+		devs, binds, err := xunix.GPUs(ctx, log, flags.hostUsrLibDir, flags.additionalDevices)
 		if err != nil {
 			return "", xerrors.Errorf("find gpus: %w", err)
 		}

--- a/xunix/gpu.go
+++ b/xunix/gpu.go
@@ -38,7 +38,7 @@ func GPUEnvs(ctx context.Context) []string {
 	return gpus
 }
 
-func GPUs(ctx context.Context, log slog.Logger, usrLibDir string) ([]Device, []mount.MountPoint, error) {
+func GPUs(ctx context.Context, log slog.Logger, usrLibDir string, additionalDevices string) ([]Device, []mount.MountPoint, error) {
 	var (
 		afs     = GetFS(ctx)
 		mounter = Mounter(ctx)
@@ -49,6 +49,22 @@ func GPUs(ctx context.Context, log slog.Logger, usrLibDir string) ([]Device, []m
 	mounts, err := mounter.List()
 	if err != nil {
 		return nil, nil, xerrors.Errorf("list mounts: %w", err)
+	}
+
+	// Append additional devices from the comma-separated list
+	if additionalDevices != "" {
+		devicePaths := strings.Split(additionalDevices, ",")
+		for _, devicePath := range devicePaths {
+			devicePath = strings.TrimSpace(devicePath)
+			if devicePath == "" {
+				continue
+			}
+			// Create a mount point for the additional device
+			mounts = append(mounts, mount.MountPoint{
+				Path: devicePath,
+				Opts: []string{"ro"},
+			})
+		}
 	}
 
 	for _, m := range mounts {

--- a/xunix/gpu_test.go
+++ b/xunix/gpu_test.go
@@ -108,7 +108,7 @@ func TestGPUs(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		devices, binds, err := xunix.GPUs(ctx, log, usrLibMountpoint)
+		devices, binds, err := xunix.GPUs(ctx, log, usrLibMountpoint, "")
 		require.NoError(t, err)
 		require.Len(t, devices, 2, "unexpected 2 nvidia devices")
 		require.Len(t, binds, 4, "expected 4 nvidia binds")


### PR DESCRIPTION
- Introduced a new environment variable `CODER_ADDITIONAL_DEVICES` to specify additional device paths.
- Updated the `GPUs` function to accept a comma-separated list of additional devices and append them to the mounts list.
- Modified the CLI flags to include the new `--additional-devices` option for user input.
- Adjusted tests to accommodate the new functionality.