### PR TITLE
Upgrade to sysbox 0.7.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,11 +31,11 @@ jobs:
         include:
           - os: ubuntu-22.04
             arch: linux/amd64
-            sha: eeff273671467b8fa351ab3d40709759462dc03d9f7b50a1b207b37982ce40a9
+            sha: 9d6d5484f980d0a17f86c492c1262015c2afb66280bdb97215b79fde6a0261c5
             arch-suffix: amd64
           - os: depot-ubuntu-22.04-arm
             arch: linux/arm64
-            sha: eae9c0e91ddd39bd1826d6a7a313a73d42a8449ef5113e9d6d118b559cb809ba
+            sha: 04ca894ae0b53f0fa54eaacc173ce40363c9a95ea5450f773716a84ef650a69b
             arch-suffix: arm64
     runs-on: ${{ matrix.os }}
     steps:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -6,7 +6,7 @@ ARG TARGETARCH
 # We don't hardcode it here because we have to be able to build both
 # amd and arm
 ARG SYSBOX_SHA
-ARG SYSBOX_VERSION="0.7.0"
+ARG SYSBOX_VERSION="0.7.1"
 ARG SYSBOX_DEB="sysbox-ce_$SYSBOX_VERSION-0.linux_$TARGETARCH.deb"
 
 # Copy configuration files to appropriate locations

--- a/scripts/sysbox_sha.sh
+++ b/scripts/sysbox_sha.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 case "${1:-linux/$(go env GOARCH)}" in
 	linux/amd64)
-		printf '%s\n' 'eeff273671467b8fa351ab3d40709759462dc03d9f7b50a1b207b37982ce40a9'
+		printf '%s\n' '9d6d5484f980d0a17f86c492c1262015c2afb66280bdb97215b79fde6a0261c5'
 		;;
 	linux/arm64)
-		printf '%s\n' 'eae9c0e91ddd39bd1826d6a7a313a73d42a8449ef5113e9d6d118b559cb809ba'
+		printf '%s\n' '04ca894ae0b53f0fa54eaacc173ce40363c9a95ea5450f773716a84ef650a69b'
 		;;
 	*)
 		echo "unsupported architecture: ${1:-}" >&2


### PR DESCRIPTION
sysbox 0.7.1 (released 2026-07-31) fixes [nestybox/sysbox#998](https://github.com/nestybox/sysbox/issues/998): a deadlock in sysbox-fs's zombie reaper that can occur when many Docker containers are started/stopped concurrently inside a Sysbox container. Per the release notes:

> Fix deadlock in sysbox-fs that could occur when many Docker containers are started/stopped concurrently inside a Sysbox container (issue #998).

The deadlock wedges the affected Sysbox container and, per the issue report, also hangs *other* Sysbox containers on the same host (`docker run --runtime=sysbox-runc` blocks indefinitely) until `sysbox` is restarted. It's fixed upstream in sysbox-fs via [nestybox/sysbox-fs#119](https://github.com/nestybox/sysbox-fs/pull/119) (`TryLock` in the reaper to avoid blocking new FUSE handlers behind a pending writer lock) and [nestybox/sysbox-fs#121](https://github.com/nestybox/sysbox-fs/pull/121) (replace synchronous child-process waits with async reaping so the reaper's lock isn't held indefinitely on a slow `nsenter` exit).

## Checksum provenance

Downloaded both `.deb` packages directly from the official release URLs and verified locally before use:

```
$ curl -fsSL -o sysbox-ce_0.7.1-0.linux_amd64.deb https://downloads.nestybox.com/sysbox/releases/v0.7.1/sysbox-ce_0.7.1-0.linux_amd64.deb
$ curl -fsSL -o sysbox-ce_0.7.1-0.linux_arm64.deb https://downloads.nestybox.com/sysbox/releases/v0.7.1/sysbox-ce_0.7.1-0.linux_arm64.deb
$ shasum -a 256 sysbox-ce_0.7.1-0.linux_amd64.deb
9d6d5484f980d0a17f86c492c1262015c2afb66280bdb97215b79fde6a0261c5  sysbox-ce_0.7.1-0.linux_amd64.deb
$ shasum -a 256 sysbox-ce_0.7.1-0.linux_arm64.deb
04ca894ae0b53f0fa54eaacc173ce40363c9a95ea5450f773716a84ef650a69b  sysbox-ce_0.7.1-0.linux_arm64.deb
```

Both match the checksums published in the [sysbox v0.7.1 GitHub release notes](https://github.com/nestybox/sysbox/releases/tag/v0.7.1).

## Shape

Follows the same three-file pattern as #163 (and #145 before it) for a sysbox version bump, updated for the current layout where the SHA lives in `scripts/sysbox_sha.sh` (added in #171) rather than the `Makefile`:

- `deploy/Dockerfile`: bump `SYSBOX_VERSION` `0.7.0` -> `0.7.1`
- `scripts/sysbox_sha.sh`: bump both arch checksums
- `.github/workflows/release.yaml`: bump the matching `sha` values in the release build matrix (this file still carries its own copy of the checksums alongside the script)

No other files reference the pinned version or checksums.

## Testing

Built the image locally on native arm64 (`make -j ARCH=linux/arm64 build/image/envbox`) as a smoke test — sysbox-ce 0.7.1 downloads, its checksum verifies, and it installs cleanly in the image; `envbox` binary runs. Didn't attempt cross-arch (amd64) build locally; CI's release matrix builds both natively.